### PR TITLE
Update APK-Info-Shell-Integration.bat

### DIFF
--- a/APK-Info-Shell-Integration.bat
+++ b/APK-Info-Shell-Integration.bat
@@ -5,11 +5,11 @@ ECHO.
 
 for %%H in (HKCU) do (
 	REG ADD "%%H\SOFTWARE\Classes\.apk" /ve /t REG_SZ /d "APK-Info" /f >nul 2>nul
-	REG ADD "%%H\SOFTWARE\Classes\APK-Info\DefaultIcon" /ve /t REG_SZ /d "\"%cd%\APK-Info.exe\"" /f >nul 2>nul
+	REG ADD "%%H\SOFTWARE\Classes\APK-Info\DefaultIcon" /ve /t REG_SZ /d "%cd%\APK-Info.exe" /f >nul 2>nul
 	REG ADD "%%H\SOFTWARE\Classes\APK-Info\shell\open" /ve /t REG_SZ /d "APK-Info" /f >nul 2>nul
-	REG ADD "%%H\SOFTWARE\Classes\APK-Info\shell\open\command" /ve /t REG_SZ /d "\"%cd%\APK-Info.exe\" \"%%1\"" /f >nul 2>nul
+	REG ADD "%%H\SOFTWARE\Classes\APK-Info\shell\open\command" /ve /t REG_SZ /d "%cd%\APK-Info.exe %%1" /f >nul 2>nul
 	
-	REG ADD "%%H\SOFTWARE\Classes\SystemFileAssociations\.apk\Shell\APK-Info\Command" /ve /t REG_SZ /d "\"%cd%\APK-Info.exe\" \"%%1\"" /f >nul 2>nul
+	REG ADD "%%H\SOFTWARE\Classes\SystemFileAssociations\.apk\Shell\APK-Info\Command" /ve /t REG_SZ /d "%cd%\APK-Info.exe %%1" /f >nul 2>nul
 )
 
 ECHO APK-Info shell integration completed!


### PR DESCRIPTION
I have modified the .bat so that it works in windows 11. (cf. https://github.com/Enyby/APK-Info/issues/9) The \" was the cause of this issue.